### PR TITLE
Contact computation speedup

### DIFF
--- a/plcc/src/plcc/Main.java
+++ b/plcc/src/plcc/Main.java
@@ -1499,6 +1499,11 @@ public class Main {
                         }
                     }
                     
+                    if(s.equals("--chain-spheres-speedup")) {
+                        argsUsed[i] = true;
+                        Settings.set("plcc_B_chain_spheres_speedup", "true");
+                    }
+                    
                     
 
                 } //end for loop
@@ -10548,6 +10553,7 @@ public class Main {
         System.out.println("   --force                 : process a PDB file even if the resolution is too bad or the number of residues is too low according to settings.");
         System.out.println("   --cluster               : Set all options for cluster mode. Equals '-f -u -k -s -G -i -Z -P'.");
         System.out.println("   --cg-threshold <Int>    : Overwrites setting for contact thresholds for edges in complex graphs.");
+        System.out.println("   --chain-spheres-speedup : speedup for contact computation based on comparison of chain spheres");
         System.out.println("");
         System.out.println("The following options only make sense for database maintenance:");
         System.out.println("--set-pdb-representative-chains-pre <file> <k> : Set non-redundant chain status for all chains in DB from XML file <file>. <k> determines what to do with existing flags, valid options are 'keep' or 'remove'. Get the file from PDB REST API. Run this pre-update, BEFORE new data will be added.");

--- a/plcc/src/plcc/Main.java
+++ b/plcc/src/plcc/Main.java
@@ -2152,6 +2152,14 @@ public class Main {
         //for(Integer i = 0; i < SSEs.size(); i++) {
         //    System.out.println("  " + SSEs.get(i));
         //}
+        
+        // If only one chain is present disable chain spheres speedup to avoid
+        // costly pre processing
+        if (Settings.getBoolean("plcc_B_chain_spheres_speedup") && chains.size() == 1) {
+            Settings.set("plcc_B_chain_spheres_speedup", "False");
+            System.out.println("Note: Chain spheres speedup was turned on in settings, but only one chain was detected. " +
+                    "To save time, setting was turned off for this structure.");
+        }
 
         
         if(Settings.getBoolean("plcc_B_contact_debug_dysfunct")) {

--- a/plcc/src/plcc/Main.java
+++ b/plcc/src/plcc/Main.java
@@ -2161,19 +2161,27 @@ public class Main {
             globalMaxSeqNeighborResDist = 1000;
         }
         else {
-            // All residues exist, we can now calculate their maximal center sphere radius
-            globalMaxCenterSphereRadius = getGlobalMaxCenterSphereRadius(residues);
-            if(! (silent || Settings.getBoolean("plcc_B_only_essential_output"))) {
-                System.out.println("  Maximal center sphere radius for all residues is " + globalMaxCenterSphereRadius + ".");
-            }
+            
+            if (Settings.getBoolean("plcc_B_chain_spheres_speedup")) {
+                // does currently not use Res skipping, so no preprocessing needed
+                // set the values to be sure that everything works properly
+                globalMaxCenterSphereRadius = Integer.MAX_VALUE;
+                globalMaxSeqNeighborResDist = Integer.MAX_VALUE; 
+            } else {
+                // All residues exist, we can now calculate their maximal center sphere radius
+                globalMaxCenterSphereRadius = getGlobalMaxCenterSphereRadius(residues);
+                if(! (silent || Settings.getBoolean("plcc_B_only_essential_output"))) {
+                    System.out.println("  Maximal center sphere radius for all residues is " + globalMaxCenterSphereRadius + ".");
+                }
 
-            // ... and the maximal distance between neighbors in the AA sequence.
-            // Note that this is a lot less useful with ligands enabled since they are always listed at the 
-            //  end of the chainName and may be far (in 3D) from their predecessor in the sequence.
-            globalMaxSeqNeighborResDist = getGlobalMaxSeqNeighborResDist(residues);     
-            if(! (silent || Settings.getBoolean("plcc_B_only_essential_output"))) {
-                System.out.println("  Maximal distance between residues that are sequence neighbors is " + globalMaxSeqNeighborResDist + ".");
-            }
+                // ... and the maximal distance between neighbors in the AA sequence.
+                // Note that this is a lot less useful with ligands enabled since they are always listed at the 
+                //  end of the chainName and may be far (in 3D) from their predecessor in the sequence.
+                globalMaxSeqNeighborResDist = getGlobalMaxSeqNeighborResDist(residues);     
+                if(! (silent || Settings.getBoolean("plcc_B_only_essential_output"))) {
+                    System.out.println("  Maximal distance between residues that are sequence neighbors is " + globalMaxSeqNeighborResDist + ".");
+                }
+            }        
         }
         // ... and fill in the frequencies of all AAs in this protein.
         getAADistribution(residues);

--- a/plcc/src/plcc/Main.java
+++ b/plcc/src/plcc/Main.java
@@ -4841,6 +4841,44 @@ public class Main {
     }
     
     
+    
+    public static ArrayList<ResContactInfo> calculateAllContactsChainSphereSpeedup(List<Chain> chains) {
+        Boolean silent = Settings.getBoolean("plcc_B_silent");
+        Chain chainA, chainB;
+        Integer chainCounts = chains.size();
+        
+        if(Settings.getBoolean("plcc_B_contact_debug_dysfunct")) {
+            chainCounts = 2;
+            System.out.println("DEBUG: Warning: Limiting residue contact computation to the first " + chainCounts + " chains and their residues.");            
+        }   
+        
+        long numResContactsChecked, numResContactsPossible, numResContactsImpossible, numCmpSkipped;
+        numResContactsChecked = numResContactsPossible = numResContactsImpossible = numCmpSkipped = 0;
+
+        long numResToSkip, spaceBetweenResidues;
+        ResContactInfo rci;
+        ArrayList<ResContactInfo> contactInfo = new ArrayList<ResContactInfo>();
+
+        Integer atomRadius = Settings.getInteger("plcc_I_atom_radius");
+        Integer atomRadiusLig = Settings.getInteger("plcc_I_lig_atom_radius");
+
+        Integer globalMaxCollisionRadius = globalMaxCenterSphereRadius + atomRadius;
+        Integer globalMaxCenterSphereDiameter = globalMaxCollisionRadius * 2;
+        Integer numIgnoredLigandContacts = 0;
+        
+        //TODO let chains compute their center and radius
+        
+        //TODO loop over chains and residues
+        
+        
+        
+        
+        
+        
+        return contactInfo;
+    }
+    
+    
     /**
      * Calculates all contacts between the residues in res.
      * @param res A list of Residue objects.

--- a/plcc/src/plcc/Main.java
+++ b/plcc/src/plcc/Main.java
@@ -2260,6 +2260,11 @@ public class Main {
             cInfoThisChain = null;
         }
         
+        if (Settings.getBoolean("plcc_B_debug_only_contact_comp")) {
+            System.out.println("Exiting now as requested by settings.");
+            System.exit(0);
+        }
+        
         // DEBUG: compare computed contacts with those from a geom_neo file
         if(compareResContacts) {
             if(separateContactsByChain) {

--- a/plcc/src/plcc/Main.java
+++ b/plcc/src/plcc/Main.java
@@ -2240,7 +2240,11 @@ public class Main {
                 cInfo = calculateAllContactsAlternativeModel(residues);
             }
             else {
-                cInfo = calculateAllContacts(residues);
+                if (Settings.getBoolean("plcc_B_chain_spheres_speedup")) {            
+                    cInfo = calculateAllContactsChainSphereSpeedup(chains);
+                } else {
+                    cInfo = calculateAllContacts(residues);
+                }
             }
             if(! silent) {
                 System.out.println("Received data on " + cInfo.size() + " residue contacts that have been confirmed on atom level.");
@@ -4867,6 +4871,9 @@ public class Main {
         Integer numIgnoredLigandContacts = 0;
         
         //TODO let chains compute their center and radius
+        for (Chain c : chains) {
+            c.computeChainCenterAndRadius();
+        }
         
         //TODO loop over chains and residues
         

--- a/plcc/src/plcc/Main.java
+++ b/plcc/src/plcc/Main.java
@@ -4965,9 +4965,8 @@ public class Main {
                 }
             }
             
-            
+            // do contact check between chains (only if chains overlap!)
             for (int l = k + 1; l < chainCounts; l++) {
-                
                 
                 chainB = chains.get(l);
                 int chainBNumberResidues = chainB.getResidues().size();
@@ -4988,7 +4987,6 @@ public class Main {
 
                             res2 = residuesB.get(j);
 
-                            // DEBUG
                             if (Settings.getInteger("plcc_I_debug_level") >= 1) {
                                 if(! silent) {
                                     System.out.println("  Checking DSSP pair " + res1.getDsspResNum() + "/" + res2.getDsspResNum() + "...");

--- a/plcc/src/plcc/Main.java
+++ b/plcc/src/plcc/Main.java
@@ -5130,7 +5130,10 @@ public class Main {
                 // DEBUG
                 if(Settings.getInteger("plcc_I_debug_level") >= 1) {
                     if(! silent) {
-                        System.out.println("  Checking DSSP pair " + a.getDsspResNum() + "/" + b.getDsspResNum() + "...");
+                        System.out.println("  Checking DSSP pair " + a.getDsspResNum() + " (Chain " + 
+                                a.getChainID() + " Residue " + a.getPdbResNum() + ") and " + 
+                                b.getDsspResNum() + " (Chain " +  b.getChainID() + " Residue " +
+                                b.getPdbResNum() + ") ...");
                     }
                     //System.out.println("    " + a.getAtomsString());
                     //System.out.println(a.atomInfo());
@@ -5495,7 +5498,7 @@ public class Main {
                 dist = x.distToAtom(y);
 
                 if(x.atomContactTo(y)) {             // If a contact is detected, Atom.atomContactTo() returns true
-                                                    
+                    
 
                     // The van der Waals radii spheres overlap, contact found.
                     numPairContacts[ResContactInfo.TT]++;   // update total number of contacts for this residue pair
@@ -5703,7 +5706,7 @@ public class Main {
         else {
             result = null;
         }
-
+        
         return(result);         // This is null if no contact was detected
         
     }

--- a/plcc/src/plcc/Settings.java
+++ b/plcc/src/plcc/Settings.java
@@ -253,6 +253,7 @@ public class Settings {
         defSet("plcc_S_debug_compareSSEContactsFile", "geo.dat_ptgl", "The path to the geo.dat file to use for SSE level contact comparison.");                
         defSet("plcc_B_contact_debug_dysfunct", "false", "Atom level contact debugging mode. WARNING: When this is true, plcc will abort after the first few residues and produce wrong overall results!");
         defSet("plcc_B_debug_only_parse", "false", "Exit after parsing. WARNING: When this is true, plcc will abort after parsing and not produce results!");
+        defSet("plcc_B_debug_only_contact_comp", "false", "Exit after contact computation. WARNING: When this is true, plcc will abort after contact computation and not produce results!");
         
         defSet("plcc_B_set_pdb_representative_chains_post", "false", "Whether this plcc run should assign the representative PDB chains from the XML file in the info table of the database and then exit. Requires path to XML file.");
         defSet("plcc_B_set_pdb_representative_chains_remove_old_labels_post", "true", "Whether the old labels should be removed from all chains in the chains table before the new ones are applied. Removed means all chains are considered NOT part of the representative set.");        

--- a/plcc/src/plcc/Settings.java
+++ b/plcc/src/plcc/Settings.java
@@ -476,7 +476,8 @@ public class Settings {
         defSet("plcc_B_alternate_aminoacid_contact_model", "false", "Use alternate residue contact model by Andreas. Skips all computations except AA graphs. EXP.");
         defSet("plcc_B_alternate_aminoacid_contact_model_with_ligands", "false", "Use alternate residue contact model including ligands by Andreas. Skips all computations except AA graphs. EXP.");
         defSet("plcc_B_quit_after_aag", "false", "Whether to quit the program after computation of amino acid graphs, prevents further work.");
-                
+        defSet("plcc_B_chain_spheres_speedup", "false", "Whether to use contact computation speedup based on comparison of chain spheres.");
+        
         // SSE definitions
         defSet("plcc_I_min_SSE_length", "3", "the minimal length in AAs a non-ligand SSE must have to be considered (PTGL-style filtering of very short SSEs)");
         defSet("plcc_B_merge_helices", "true", "whether to merge different helix types if they are adjacent in the primary structure");

--- a/plcc/src/plcc/Settings.java
+++ b/plcc/src/plcc/Settings.java
@@ -253,7 +253,7 @@ public class Settings {
         defSet("plcc_S_debug_compareSSEContactsFile", "geo.dat_ptgl", "The path to the geo.dat file to use for SSE level contact comparison.");                
         defSet("plcc_B_contact_debug_dysfunct", "false", "Atom level contact debugging mode. WARNING: When this is true, plcc will abort after the first few residues and produce wrong overall results!");
         defSet("plcc_B_debug_only_parse", "false", "Exit after parsing. WARNING: When this is true, plcc will abort after parsing and not produce results!");
-        defSet("plcc_B_debug_only_contact_comp", "false", "Exit after contact computation. WARNING: When this is true, plcc will abort after contact computation and not produce results!");
+        defSet("plcc_B_debug_only_contact_comp", "true", "Exit after contact computation. WARNING: When this is true, plcc will abort after contact computation and not produce results!");
         
         defSet("plcc_B_set_pdb_representative_chains_post", "false", "Whether this plcc run should assign the representative PDB chains from the XML file in the info table of the database and then exit. Requires path to XML file.");
         defSet("plcc_B_set_pdb_representative_chains_remove_old_labels_post", "true", "Whether the old labels should be removed from all chains in the chains table before the new ones are applied. Removed means all chains are considered NOT part of the representative set.");        

--- a/plcc/src/proteingraphs/ContactMatrix.java
+++ b/plcc/src/proteingraphs/ContactMatrix.java
@@ -657,6 +657,14 @@ public class ContactMatrix {
                     }
                     // HE ----- Helix - Sheet contacts
                     else if( (a.isHelix() && b.isBetaStrand()) || (b.isHelix() && a.isBetaStrand())  ) {
+                        //DEBUG - NOTE: only reporting this stuff for H-E right now
+                        if (Settings.getInteger("plcc_I_debug_level") >= 3) {
+                            System.out.println("   [DEBUG LV 3] NOTE: only reporting this for H-E (see code)");
+                            System.out.println("   [DEBUG LV 3] " + a.toString());
+                            System.out.println("   [DEBUG LV 3] " + b.toString());
+                            System.out.println("    [DEBUG LV 3] #BB: " + contBB[i][j] + " #BC: " + 
+                                    contBC[i][j] + " #CB: " + contCB[i][j] + " #CC: " + contCC[i][j]);
+                        }
                         //if( ( (contBB[i][j] > 1) && (contBC[i][j] + contCB[i][j] > 3) ) || (contCC[i][j] > 3)) {
                         if( (contBB[i][j] > 1) || (contBC[i][j] + contCB[i][j] > 3) || (contCC[i][j] > 3)) {
                             contSSE[i][j] = 1;

--- a/plcc/src/proteinstructure/Atom.java
+++ b/plcc/src/proteinstructure/Atom.java
@@ -102,7 +102,9 @@ public class Atom implements java.io.Serializable {
         dd += (coordY - dy) * (coordY - dy);
         dd += (coordZ - dz) * (coordZ - dz);
 
-        di = (int)Math.sqrt(dd);
+        // di = (int)Math.sqrt(dd);
+        // jnw: lets round instead of truncate the result
+        di = (int)Math.round(Math.sqrt(dd));
         
         return(di);
     }

--- a/plcc/src/proteinstructure/Atom.java
+++ b/plcc/src/proteinstructure/Atom.java
@@ -185,6 +185,19 @@ public class Atom implements java.io.Serializable {
         //    System.err.println("ERROR: Distance of atoms " + this.getPdbAtomNum() + " and " + a.getPdbAtomNum() + " is " + dist + ", but should be > 0.");
         //    System.exit(1);
         //}
+        
+        if (Settings.getInteger("plcc_I_debug_level") >= 2) {
+            if (dist < maxDist) {
+                System.out.println("   [DEBUG LV 2] Atom " + this.getPdbAtomNum() + " " +
+                    this.getCoordString() + " and atom " + 
+                    a.getPdbAtomNum() + " " + a.getCoordString() + " have distance " + dist + " => contact!");
+            } else {
+                System.out.println("   [DEBUG LV 2] Atom " + this.getPdbAtomNum() + " " +
+                    this.getCoordString() + " and atom " + 
+                    a.getPdbAtomNum() + " " + a.getCoordString() + " have distance " + dist);
+            }
+        }
+            
 
         if( dist < maxDist) {
             // Contact!

--- a/plcc/src/proteinstructure/Atom.java
+++ b/plcc/src/proteinstructure/Atom.java
@@ -98,9 +98,9 @@ public class Atom implements java.io.Serializable {
         Double dd = 0.0;
         Integer di;
         
-        dd = dd + dx * dx;
-        dd = dd + dy * dy;
-        dd = dd + dz * dz;
+        dd += (coordX - dx) * (coordX - dx);
+        dd += (coordY - dy) * (coordY - dy);
+        dd += (coordZ - dz) * (coordZ - dz);
 
         di = (int)Math.sqrt(dd);
         

--- a/plcc/src/proteinstructure/Atom.java
+++ b/plcc/src/proteinstructure/Atom.java
@@ -74,24 +74,35 @@ public class Atom implements java.io.Serializable {
      * @return the euclidian distance, rounded to an Integer
      */
     public Integer distToAtom(Atom a) {
-        Double dd = 0.0;
-        Integer di, dx, dy, dz = 0;
-
-        dx = this.getCoordX() - a.getCoordX();
-        dd = dd + dx * dx;
-        dy = this.getCoordY() - a.getCoordY();
-        dd = dd + dy * dy;
-        dz = this.getCoordZ() - a.getCoordZ();
-        dd = dd + dz * dz;
-
-        di = (int)Math.sqrt(dd);
+        Integer di;
+        di = distToPoint(a.getCoordX(), a.getCoordY(), a.getCoordZ());
         
         if(Settings.getBoolean("plcc_B_contact_debug_dysfunct")) {
             if(this.isCalphaAtom() && a.isCalphaAtom()) {
-                System.out.println("Distance between C-alpha atoms " + this.pdbAtomNumber + " of " + this.getPdbResNum() + " and " + a.pdbAtomNumber + " of " + a.getPdbResNum() + " is " + di + " (" + dd + " before sqrt).");
+                System.out.println("Distance between C-alpha atoms " + this.pdbAtomNumber + " of " + this.getPdbResNum() + " and " + a.pdbAtomNumber + " of " + a.getPdbResNum() + " is " + di + " (-- before sqrt -> due to change of function not given).");
                 System.out.println(this.getCoordString() + "/" + a.getCoordString());
             }            
         }
+        
+        return(di);
+    }
+    
+    /**
+     * Returns the distance from this atom to a point in 3D.
+     * @param dx X coordinate as 10th of Angström in int
+     * @param dy Y coordinate as 10th of Angström in int
+     * @param dz Z coordinate as 10th of Angström in int
+     * @return the euclidian distance, rounded to an int
+     */
+    public Integer distToPoint(int dx, int dy, int dz) {
+        Double dd = 0.0;
+        Integer di;
+        
+        dd = dd + dx * dx;
+        dd = dd + dy * dy;
+        dd = dd + dz * dz;
+
+        di = (int)Math.sqrt(dd);
         
         return(di);
     }

--- a/plcc/src/proteinstructure/Chain.java
+++ b/plcc/src/proteinstructure/Chain.java
@@ -170,6 +170,9 @@ public class Chain implements java.io.Serializable {
         return new String[] { sbChemProp.toString(), sbSSE.toString() };
     }
     
+    /**
+     * Computes the geometrical center of all atoms and the largest distance from center to an atom (=radius).
+     */
     public void computeChainCenterAndRadius() {
         // compute center
         Integer[] tmpCenter = new Integer[3];
@@ -192,5 +195,21 @@ public class Chain implements java.io.Serializable {
         }
             
         // TODO compute radius
+        int tmpBiggestDist = 0;
+        int tmpCurrentDist = 0;
+        for (Residue r : residues) {
+            for (Atom a : r.getAtoms()) {
+                tmpCurrentDist = a.distToPoint(chainCenter[0], chainCenter[1], chainCenter[2]);
+                // System.out.println("[DEBUG] Distance to center from atom " + a.toString() + " is " + String.valueOf(tmpCurrentDist));
+                if (tmpCurrentDist > tmpBiggestDist) {
+                    tmpBiggestDist = tmpCurrentDist;
+                }
+            }
+        }
+        
+        if (Settings.getInteger("plcc_I_debug_level") > 0) {
+            System.out.println("[DEBUG] Radius of chain " + pdbChainID + " is " + String.valueOf(tmpBiggestDist));
+        }
+        
     }
 }

--- a/plcc/src/proteinstructure/Chain.java
+++ b/plcc/src/proteinstructure/Chain.java
@@ -21,14 +21,16 @@ import io.IO;
 public class Chain implements java.io.Serializable {
 
     // declare class vars
-    private String pdbChainID = null;           // chain ID from PDB file
-    private String dsspChainID = null;          // chain ID from DSSP file
-    private ArrayList<Residue> residues = null;          // a list of all Residues of the Chain
-    private String macromolID = null;             // the macromolecule ID of the chain in the PDB file, defines chains forming a single macromolecule
-    private String macromolName = null;         // the macromol name from the PDB file
+    private String pdbChainID = null;                // chain ID from PDB file
+    private String dsspChainID = null;               // chain ID from DSSP file
+    private ArrayList<Residue> residues = null;      // a list of all Residues of the Chain
+    private String macromolID = null;                // the macromolecule ID of the chain in the PDB file, defines chains forming a single macromolecule
+    private String macromolName = null;              // the macromol name from the PDB file
     private String modelID = null;
-    private Model model = null;                 // the Model of this Chain
-    private ArrayList<String> homologues = null; // a list of homologue chains (defined by PDB COMPND)
+    private Model model = null;                      // the Model of this Chain
+    private ArrayList<String> homologues = null;     // a list of homologue chains (defined by PDB COMPND)
+    private Integer[] chainCenter = new Integer[3];  // X-/Y-/Z-coordinates as 10th of Angström of the center of all non-H atoms
+    private Integer radiusFromCenter = null;
 
     // constructor
     public Chain(String ci) { pdbChainID = ci; residues = new ArrayList<Residue>(); }

--- a/plcc/src/proteinstructure/Chain.java
+++ b/plcc/src/proteinstructure/Chain.java
@@ -13,6 +13,7 @@ import proteinstructure.SSE;
 import java.util.ArrayList;
 import java.util.Arrays;
 import io.IO;
+import plcc.Settings;
 
 /**
  * Represents a protein chain in a PDB file.
@@ -46,6 +47,8 @@ public class Chain implements java.io.Serializable {
     public Model getModel() { return(model); }
     public ArrayList<Residue> getResidues() { return(residues); }
     public ArrayList<String> getHomologues() { return(homologues); }
+    public Integer[] getChainCenter() { return(chainCenter); }
+    public Integer getRadiusFromCenter() { return(radiusFromCenter); }
     
     /**
      * Returns a list of all ligand residues in this chain.
@@ -165,5 +168,29 @@ public class Chain implements java.io.Serializable {
         
         //System.out.println("Added " + numSeps + " separators.");
         return new String[] { sbChemProp.toString(), sbSSE.toString() };
+    }
+    
+    public void computeChainCenterAndRadius() {
+        // compute center
+        Integer[] tmpCenter = new Integer[3];
+        tmpCenter[0] = tmpCenter[1] = tmpCenter[2] = 0;
+        int tmpAtomNumber = 0;
+        for (Residue r : residues) {
+            for (Atom a : r.getAtoms()) {
+                tmpCenter[0] += a.getCoordX();
+                tmpCenter[1] += a.getCoordY();
+                tmpCenter[2] += a.getCoordZ();
+                tmpAtomNumber += 1;
+            }
+        }
+        chainCenter[0] = tmpCenter[0] / tmpAtomNumber;
+        chainCenter[1] = tmpCenter[1] / tmpAtomNumber;
+        chainCenter[2] = tmpCenter[2] / tmpAtomNumber;
+        
+        if (Settings.getInteger("plcc_I_debug_level") > 0) {
+            System.out.println("[DEBUG] Center of chain " + pdbChainID + " is at " + Arrays.toString(chainCenter));
+        }
+            
+        // TODO compute radius
     }
 }

--- a/plcc/src/proteinstructure/Chain.java
+++ b/plcc/src/proteinstructure/Chain.java
@@ -221,7 +221,7 @@ public class Chain implements java.io.Serializable {
             radiusFromCenter = tmpBiggestDist;
         
         } else {
-            System.out.println("[WARNING] Chain " + this.pdbChainID + " seems not to hold protein atoms. No center can be detected.");
+            System.out.println("  [WARNING] Chain " + this.pdbChainID + " seems not to hold protein atoms. No center can be detected.");
             radiusFromCenter = -1;
         }        
     }
@@ -242,9 +242,9 @@ public class Chain implements java.io.Serializable {
         Integer dist, tmpSum;
         
         tmpSum = 0;
-        tmpSum += this.chainCenter[0] - c.getChainCenter()[0] * this.chainCenter[0] - c.getChainCenter()[0];
-        tmpSum += this.chainCenter[1] - c.getChainCenter()[1] * this.chainCenter[1] - c.getChainCenter()[1];
-        tmpSum += this.chainCenter[2] - c.getChainCenter()[2] * this.chainCenter[2] - c.getChainCenter()[2];
+        tmpSum += (this.chainCenter[0] - c.getChainCenter()[0]) * (this.chainCenter[0] - c.getChainCenter()[0]);
+        tmpSum += (this.chainCenter[1] - c.getChainCenter()[1]) * (this.chainCenter[1] - c.getChainCenter()[1]);
+        tmpSum += (this.chainCenter[2] - c.getChainCenter()[2]) * (this.chainCenter[2] - c.getChainCenter()[2]);
         
         dist = (int)Math.round(Math.sqrt(tmpSum));
         
@@ -257,6 +257,15 @@ public class Chain implements java.io.Serializable {
         //System.out.println("    Center sphere radius for PDB residue " + this.getPdbResNum() + " = " + this.getCenterSphereRadius() + ", for " + r.getPdbResNum() + " = " + r.getCenterSphereRadius() + ", atom radius is " + atomRadius + ".");
         //System.out.println("    DSSP Res distance " + this.getDsspResNum() + "/" + r.getDsspResNum() + " is " + dist + " (no contacts possible above distance " + maxDistForContact + ").");
 
+        if (Settings.getInteger("plcc_I_debug_level") > 0) {
+            System.out.println("[DEBUG][CHAIN] Chain " + this.pdbChainID + " and " + c.pdbChainID);
+            System.out.println(" ... mid points: " + this.chainCenter[0] + "|" + this.chainCenter[1] + "|" + this.chainCenter[2]);
+            System.out.println(" ... mid points: " + c.chainCenter[0] + "|" + c.chainCenter[1] + "|" + c.chainCenter[2]);
+            System.out.println(" ... radii: " + this.radiusFromCenter + " and " + c.radiusFromCenter);
+            System.out.println(" ... distance: " + dist);
+            System.out.println(" ... summedSpheres: " + summedSpheres);
+        }
+        
         if(dist <= summedSpheres) {
             return(true);
         }


### PR DESCRIPTION
Add contact computation speedup (turned on by settings or command line argument). It applies a pre processing by computing the center of each chain the distance to the farthest atom. The residues of two chains only need to be considered while computing the contacts if the chain spheres overlap. This is especially efficient for structures with many chains.